### PR TITLE
Colors now save and load when the client is closed and opened. Colors…

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -107,4 +107,15 @@ impl AppState {
     pub fn clear_highlight_cache(&mut self) {
         self.highlight_cache.clear();
     }
+    
+    /// Show error dialog for config loading issues
+    pub fn show_config_error(&mut self, error_msg: String) {
+        self.show_error_dialog = true;
+        self.error_message = error_msg;
+    }
+    
+    /// Save current color configuration to disk
+    pub fn save_color_config(&self) -> anyhow::Result<()> {
+        crate::config::save_color_config(&self.colors)
+    }
 }

--- a/src/handlers/events/dialog_tests.rs
+++ b/src/handlers/events/dialog_tests.rs
@@ -9,6 +9,7 @@ use std::fs;
 use crate::app::AppState;
 use crate::handlers::events::dialogs::*;
 use crate::handlers::file_ops::load_directory_contents;
+use crate::config::get_default_colors;
 
 /// Helper function to create a test AppState with temporary directory
 fn create_test_app_state() -> (AppState, TempDir) {
@@ -19,6 +20,7 @@ fn create_test_app_state() -> (AppState, TempDir) {
         1000,
         0.7,
         false,
+        get_default_colors(),
     ).expect("Failed to create AppState");
     
     app.current_directory = temp_dir.path().to_path_buf();

--- a/src/handlers/events/dialogs.rs
+++ b/src/handlers/events/dialogs.rs
@@ -262,6 +262,10 @@ pub fn handle_color_dialog(app: &mut AppState, code: KeyCode) {
             app.color_dialog_scroll_offset = 0;
             app.color_dialog_selection_scroll_offset = 0;
         }
+        KeyCode::Char('r') | KeyCode::Char('R') => {
+            // Reset colors to defaults
+            app.colors.reset_to_defaults();
+        }
         KeyCode::Up => {
             if app.color_dialog_option > 0 {
                 app.color_dialog_option -= 1;

--- a/src/handlers/events/input_tests.rs
+++ b/src/handlers/events/input_tests.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc;
 use tempfile::TempDir;
 
 use crate::app::AppState;
+use crate::config::get_default_colors;
 use crate::handlers::events::input::*;
 use crate::api::Message;
 
@@ -18,6 +19,7 @@ fn create_test_app_state() -> (AppState, TempDir) {
         1000,
         0.7,
         false,
+        get_default_colors(),
     ).expect("Failed to create AppState");
     
     app.current_directory = temp_dir.path().to_path_buf();

--- a/src/main_loop_tests.rs
+++ b/src/main_loop_tests.rs
@@ -7,7 +7,7 @@ use tokio::time::{timeout, Duration};
 
 use crate::app::AppState;
 use crate::api::Message;
-use crate::config::{SCROLL_ON_USER_INPUT, SCROLL_ON_API_RESPONSE, default_test_colors};
+use crate::config::{SCROLL_ON_USER_INPUT, SCROLL_ON_API_RESPONSE, get_default_colors};
 
 /// Helper function to create a test app state
 fn create_main_loop_test_app() -> AppState {
@@ -17,7 +17,7 @@ fn create_main_loop_test_app() -> AppState {
         1024,
         0.7,
         true, // simulate mode
-        default_test_colors(),
+        get_default_colors(),
     ).expect("Failed to create test app state")
 }
 


### PR DESCRIPTION
… can be reset from the command-line. I think they can also be reset from within the UI, but Claude didn't tell me which key does that. I'll pry that out of him, next.